### PR TITLE
Fix identify refund transaction

### DIFF
--- a/Model/Method/AbstractMethod.php
+++ b/Model/Method/AbstractMethod.php
@@ -301,7 +301,7 @@ abstract class AbstractMethod extends \Magento\Payment\Model\Method\AbstractMeth
         }
 
         // Load transaction Data
-        $transactionId = $payment->getLastTransId();
+        $transactionId = $payment->getData('refund_transaction_id');
         $transactionRepository = \Magento\Framework\App\ObjectManager::getInstance()->get('Magento\Sales\Model\Order\Payment\Transaction\Repository');
 
         /** @var \Magento\Sales\Model\Order\Payment\Transaction $transaction */


### PR DESCRIPTION
Fix for bug when refunding online multiple invoices. When creating second credit memo refund transaction is retrieved as payment last transaction.